### PR TITLE
Add Deposit to schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -40,14 +40,13 @@ type Proposal @entity {
   txHash: String!
   type: String!
   proposer: String!
-  initialDepositDenom: String!
-  initialDepositAmount: String!
   authority: String!
   title: String!
   description: String!
   metadata: String
   votes: [Vote!]! @derivedFrom(field: "proposal")
   contents: [Content!]! @derivedFrom(field: "proposal")
+  deposits: [Deposit!]! @derivedFrom(field: "proposal")
 }
 
 type Content @entity {
@@ -68,12 +67,22 @@ type SoftwareUpgradeProposal @entity {
 
 type Vote @entity {
   id: ID!
-  txHash: String!
   block: Block!
+  txHash: String!
   voter: String!
   option: String!
   weight: BigDecimal!
   proposal: Proposal!
+}
+
+type Deposit @entity {
+  id: ID!
+  block: Block!
+  txHash: String!
+  proposal: Proposal!
+  amount: String!
+  denom: String!
+  depositor: String!
 }
 
 #type VoteStats @aggregation(intervals: ["hour", "day"], source: "Vote") {

--- a/src/client_update.rs
+++ b/src/client_update.rs
@@ -9,6 +9,7 @@ use crate::{
         cosmos::gov::v1beta1::MsgSubmitProposal as MsgSubmitProposalV1Beta1,
         ibc::core::client::v1::ClientUpdateProposal,
     },
+    proposal_deposits::insert_deposit,
     utils::{extract_authority, extract_initial_deposit, extract_proposal_id},
 };
 
@@ -27,7 +28,7 @@ pub fn insert_client_update_proposal(
         let subject_client_id = client_update_proposal.subject_client_id.as_str();
         let substitute_client_id = client_update_proposal.substitute_client_id.as_str();
 
-        let (initial_deposit_denom, initial_deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
+        let (deposit_denom, deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
 
         let authority = extract_authority(tx_result);
 
@@ -48,9 +49,17 @@ pub fn insert_client_update_proposal(
             .set("title", title)
             .set("description", description)
             .set("proposer", proposer)
-            .set("authority", authority)
-            .set("initialDepositDenom", initial_deposit_denom)
-            .set("initialDepositAmount", initial_deposit_amount);
+            .set("authority", authority);
+
+        insert_deposit(
+            tables,
+            &proposal_id,
+            &deposit_amount,
+            &deposit_denom,
+            proposer,
+            clock,
+            tx_hash,
+        );
 
         tables
             .create_row("Content", &proposal_id)

--- a/src/index.rs
+++ b/src/index.rs
@@ -13,7 +13,10 @@ fn index_blocks(block: Block) -> Result<Keys, substreams::errors::Error> {
 
         for event in tx_result.events.iter() {
             // Index by event type
-            if event.r#type == "submit_proposal" || event.r#type == "proposal_vote" {
+            if event.r#type == "submit_proposal"
+                || event.r#type == "proposal_vote"
+                || event.r#type == "proposal_deposit"
+            {
                 let event_type_key = format!("event_type:{}", event.r#type);
                 keys.keys.push(event_type_key);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod index;
 mod other_proposals;
 mod parameter_changes;
 mod pb;
+mod proposal_deposits;
 mod proposal_votes;
 mod serde_genesis;
 mod sink;

--- a/src/other_proposals.rs
+++ b/src/other_proposals.rs
@@ -9,6 +9,7 @@ use crate::{
     pb::cosmos::gov::{
         v1::MsgSubmitProposal as MsgSubmitProposalV1, v1beta1::MsgSubmitProposal as MsgSubmitProposalV1Beta1,
     },
+    proposal_deposits::insert_deposit,
     utils::{extract_authority, extract_initial_deposit, extract_proposal_id},
 };
 
@@ -26,7 +27,7 @@ pub fn insert_other_proposal_v1(
     let description = msg.summary.as_str();
     let metadata = msg.metadata.as_str();
 
-    let (initial_deposit_denom, initial_deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
+    let (deposit_denom, deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
 
     let proposal_id = extract_proposal_id(tx_result, clock, tx_hash);
 
@@ -42,12 +43,20 @@ pub fn insert_other_proposal_v1(
         .set("block", &clock.id)
         .set("type", "Undecoded Proposal")
         .set("proposer", proposer)
-        .set("initialDepositDenom", initial_deposit_denom)
-        .set("initialDepositAmount", initial_deposit_amount)
         .set("authority", authority)
         .set("title", title)
         .set("description", description)
         .set("metadata", metadata);
+
+    insert_deposit(
+        tables,
+        &proposal_id,
+        &deposit_amount,
+        &deposit_denom,
+        proposer,
+        clock,
+        tx_hash,
+    );
 
     tables
         .create_row("Content", &proposal_id)
@@ -67,7 +76,7 @@ pub fn insert_other_proposal_v1beta1(
     let type_url = content.type_url.as_str();
     let proposer = msg.proposer.as_str();
 
-    let (initial_deposit_denom, initial_deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
+    let (deposit_denom, deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
 
     let proposal_id = extract_proposal_id(tx_result, clock, tx_hash);
 
@@ -92,11 +101,19 @@ pub fn insert_other_proposal_v1beta1(
         .set("block", &clock.id)
         .set("type", "Undecoded Proposal")
         .set("proposer", proposer)
-        .set("initialDepositDenom", initial_deposit_denom)
-        .set("initialDepositAmount", initial_deposit_amount)
         .set("authority", authority)
         .set("title", title)
         .set("description", description);
+
+    insert_deposit(
+        tables,
+        &proposal_id,
+        &deposit_amount,
+        &deposit_denom,
+        proposer,
+        clock,
+        tx_hash,
+    );
 
     tables
         .create_row("Content", &proposal_id)

--- a/src/proposal_deposits.rs
+++ b/src/proposal_deposits.rs
@@ -1,0 +1,37 @@
+use prost::Message;
+use prost_types::Any;
+use substreams::pb::substreams::Clock;
+use substreams_entity_change::tables::Tables;
+
+use crate::{pb::cosmos::gov::v1beta1::MsgDeposit, utils::extract_initial_deposit};
+
+pub fn insert_deposit(
+    tables: &mut Tables,
+    proposal_id: &str,
+    amount: &str,
+    denom: &str,
+    depositor: &str,
+    clock: &Clock,
+    tx_hash: &str,
+) {
+    let id = format!("{}-{}", proposal_id, tx_hash);
+
+    tables
+        .create_row("Deposit", &id)
+        .set("block", &clock.id)
+        .set("txHash", tx_hash)
+        .set("proposal", proposal_id)
+        .set("amount", amount)
+        .set("denom", denom)
+        .set("depositor", depositor);
+}
+
+pub fn insert_deposit_undecoded(tables: &mut Tables, msg: &Any, clock: &Clock, tx_hash: &str) {
+    if let Ok(msg_deposit) = MsgDeposit::decode(msg.value.as_slice()) {
+        let proposal_id = msg_deposit.proposal_id.to_string();
+        let depositor = msg_deposit.depositor.as_str();
+        let (denom, amount) = extract_initial_deposit(&msg_deposit.amount);
+
+        insert_deposit(tables, &proposal_id, &amount, &denom, depositor, clock, tx_hash);
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,7 @@
 use crate::blocks::insert_block;
 use crate::pb::cosmos::gov::v1beta1::MsgSubmitProposal as MsgSubmitProposalV1Beta1;
 use crate::pb::cosmos::gov::v1beta1::TextProposal;
+use crate::proposal_deposits::insert_deposit;
 use crate::utils::extract_authority;
 use crate::utils::extract_initial_deposit;
 use crate::utils::extract_proposal_id;
@@ -24,7 +25,7 @@ pub fn insert_text_proposal(
 
         let proposal_id = extract_proposal_id(tx_result, clock, tx_hash);
 
-        let (initial_deposit_denom, initial_deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
+        let (deposit_denom, deposit_amount) = extract_initial_deposit(&msg.initial_deposit);
 
         let authority = extract_authority(tx_result);
 
@@ -37,9 +38,17 @@ pub fn insert_text_proposal(
             .set("authority", authority)
             .set("block", &clock.id)
             .set("type", "Text")
-            .set("initialDepositDenom", initial_deposit_denom)
-            .set("initialDepositAmount", initial_deposit_amount)
             .set("title", title)
             .set("description", description);
+
+        insert_deposit(
+            tables,
+            &proposal_id,
+            &deposit_amount,
+            &deposit_denom,
+            proposer,
+            clock,
+            tx_hash,
+        );
     }
 }

--- a/substreams.yaml
+++ b/substreams.yaml
@@ -29,7 +29,7 @@ modules:
     blockFilter:
       module: index_blocks
       query:
-        string: "event_type:proposal_vote || event_type:submit_proposal"
+        string: "event_type:proposal_vote || event_type:submit_proposal || event_type:proposal_deposit"
     output:
       type: proto:sf.substreams.sink.entity.v1.EntityChanges
 


### PR DESCRIPTION
Traditionally, most proposals include an initial deposit that covers the entire minimum amount required to initiate voting. However, this isn't always the case. Some proposals reach the minimum threshold through multiple deposits, which may come from various contributors, not just the original proposer.

To address this, I've introduced a new `Deposit` entity that allows us to track every deposit made towards a proposal. This change offers several benefits:

1. Improved accuracy in tracking proposal funding
2. Better representation of multi-contributor scenarios
3. Enhanced data granularity for analysis

As a result of this new entity, we can now remove the `initialDepositDenom` and `initialDepositAmount` attributes from the `Proposal` entity. The `Deposit` entity will comprehensively cover all deposits, including the initial one, for every proposal.